### PR TITLE
Add Conformance section back.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -604,6 +604,22 @@ of their replacements:
 	an event type used with {{ScriptProcessorNode}}
 	objects.
 
+<h2 id="conformance">
+Confomance</h2>
+As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
+
+The key words *MAY*, *MUST*, *REQUIRED*, *SHALL*, and *SHOULD* are to be interpreted as described in [[!RFC2119]].
+
+The following conformance classes are defined by this specification:
+
+: <dfn>conforming implementation</dfn>
+:: A user agent is considered to be a <a>conforming implementation</a> if it satisfies all of the *MUST*-, *REQUIRED*- and *SHALL*-level criteria in this specification that apply to implementations.
+
+User agents that use ECMAScript to implement the APIs defined in this
+specification MUST implement them in a manner consistent with the
+ECMAScript Bindings defined in the Web IDL specification [[!WEBIDL]] as
+this specification uses that specification and terminology.
+
 <h2 id="audioapi">
 The Audio API</h2>
 


### PR DESCRIPTION
The Conformance section was missing, so put it back, with appropriate
bikeshed markup.