### PR TITLE
Fix links to currentTime

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1492,9 +1492,9 @@ Methods</h4>
 			1. Let <em>promise</em> be a new Promise.
 
 			2. If the <em>control thread state</em> flag on the
-					{{AudioContext}} is <code>closed</code> reject the promise
-					with {{InvalidStateError}}, abort these steps,
-					returning <em>promise</em>.
+				{{AudioContext}} is <code>closed</code> reject the promise
+				with {{InvalidStateError}}, abort these steps,
+				returning <em>promise</em>.
 
 			3. If the {{AudioContext/state}} attribute
 				of the {{AudioContext}} is already <code>closed</code>,

--- a/index.bs
+++ b/index.bs
@@ -712,7 +712,7 @@ interface BaseAudioContext : EventTarget {
 Attributes</h4>
 
 <dl dfn-type=attribute dfn-for=BaseAudioContext>
-	: <dfn>currenttime</dfn>
+	: <dfn>currentTime</dfn>
 	::
 		This is the time in seconds of the sample frame immediately
 		following the last sample-frame in the block of audio most
@@ -1149,7 +1149,7 @@ Methods</h4>
 	: <dfn>resume()</dfn>
 	::
 		Resumes the progression of the {{BaseAudioContext}}'s
-		{{AudioContext/currentTime}} when it has
+		{{BaseAudioContext/currentTime}} when it has
 		been suspended.
 
 		<div algorithm="resume()">
@@ -1483,7 +1483,7 @@ Methods</h4>
 		resources</a> it's using. This will not automatically release
 		all {{AudioContext}}-created objects, but will suspend the
 		progression of the {{AudioContext}}'s
-		{{AudioContext/currentTime}}, and stop
+		{{BaseAudioContext/currentTime}}, and stop
 		processing audio data.
 
 		<div algorithm="AudioContext.close()">
@@ -1492,9 +1492,9 @@ Methods</h4>
 			1. Let <em>promise</em> be a new Promise.
 
 			2. If the <em>control thread state</em> flag on the
-				{{AudioContext}} is <code>closed</code> reject the promise
-				with {{InvalidStateError}}, abort these steps,
-				returning <em>promise</em>.
+					{{AudioContext}} is <code>closed</code> reject the promise
+					with {{InvalidStateError}}, abort these steps,
+					returning <em>promise</em>.
 
 			3. If the {{AudioContext/state}} attribute
 				of the {{AudioContext}} is already <code>closed</code>,
@@ -3449,7 +3449,7 @@ Methods</h4>
 		behaves as if <code>setValueAtTime(value, currentTime)</code>
 		were called where <code>value</code> is the current value of
 		the attribute and <code>currentTime</code> is the context
-		{{AudioContext/currentTime}} at the time
+		{{BaseAudioContext/currentTime}} at the time
 		<code>exponentialRampToValueAtTime</code> is called.
 
 		If the preceding event is a <code>SetTarget</code> event, \(T_0\)
@@ -3500,7 +3500,7 @@ Methods</h4>
 		behaves as if <code>setValueAtTime(value, currentTime)</code>
 		were called where <code>value</code> is the current value of
 		the attribute and <code>currentTime</code> is the context
-		{{AudioContext/currentTime}} at the time
+		{{BaseAudioContext/currentTime}} at the time
 		<code>linearRampToValueAtTime</code> is called.
 
 		If the preceding event is a <code>SetTarget</code> event, \(T_0\)
@@ -3597,7 +3597,7 @@ Methods</h4>
 
 		<pre class=argumentdef for="AudioParam/setValueAtTime()">
 			value: The value the parameter will change to at the given time.
-			startTime: The time in the same time coordinate system as the {{BaseAudioContext}}'s {{AudioContext/currentTime}} attribute at which the parameter changes to the given value. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>startTime</code> is negative or is not a finite number.</span> If <var>startTime</var> is less than {{BaseAudioContext/currentTime}}, it is clamped to {{BaseAudioContext/currentTime}}.
+			startTime: The time in the same time coordinate system as the {{BaseAudioContext}}'s {{BaseAudioContext/currentTime}} attribute at which the parameter changes to the given value. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>startTime</code> is negative or is not a finite number.</span> If <var>startTime</var> is less than {{BaseAudioContext/currentTime}}, it is clamped to {{BaseAudioContext/currentTime}}.
 		</pre>
 
 		<div>


### PR DESCRIPTION
The dfn for currentTime was incorrectly spelled "currenttime", and
many links used AudioContext/currentTime when it should have been
BaseAudioContext/currentTime.