### PR TITLE
Fix links to getChannelData

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11479,15 +11479,15 @@ When an <a href="#acquire-the-content">acquire the content</a>
 operation is performed on an {{AudioBuffer}}, the entire operation
 can usually be implemented without copying channel data. In
 particular, the last step SHOULD be performed lazily at the next
-{{AudioBuffer/getChannelData}} call.
+{{AudioBuffer/getChannelData()}} call.
 That means a sequence of consecutive <a href="#acquire-the-content">acquire the contents</a> operations with no
-intervening {{AudioBuffer/getChannelData}} (e.g. multiple
+intervening {{AudioBuffer/getChannelData()}} (e.g. multiple
 {{AudioBufferSourceNode}}s playing the same
 {{AudioBuffer}}) can be implemented with no
 allocations or copying.
 
 Implementations can perform an additional optimization: if
-{{AudioBuffer/getChannelData}} is called on an
+{{AudioBuffer/getChannelData()}} is called on an
 {{AudioBuffer}}, fresh {{ArrayBuffer}}s have not yet been
 allocated, but all invokers of previous <a href="#acquire-the-content">acquire the content</a> operations on an
 {{AudioBuffer}} have stopped using the {{AudioBuffer}}'s data,


### PR DESCRIPTION
A few links were missing the parens for getChannelData method.