### PR TITLE
Fix link to automation event time

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3220,7 +3220,7 @@ specific to the method:
 
 The following rules will apply when calling these methods:
 
-* <a href="#dfn-automation-event-time">Automation event times</a> are
+* <a href="#automation-event-time">Automation event times</a> are
 	not quantized with respect to the prevailing sample rate. Formulas
 	for determining curves and ramps are applied to the exact numerical
 	times given when scheduling events.

--- a/index.bs
+++ b/index.bs
@@ -3220,7 +3220,7 @@ specific to the method:
 
 The following rules will apply when calling these methods:
 
-* <a href="#automation-event-time">Automation event times</a> are
+* <a>Automation event times</a> are
 	not quantized with respect to the prevailing sample rate. Formulas
 	for determining curves and ramps are applied to the exact numerical
 	times given when scheduling events.


### PR DESCRIPTION
The link id is #automation-event-time, not #dfn-automation-event-time.