### PR TITLE
Fix links to associated interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2512,8 +2512,8 @@ is called on.
 
 	1. Let <var>o</var> be a new object of type <var>n</var>.
 
-	2. Let <var>option</var> be a dictionary of the type <a href="#dfn-associated-option-object">associated</a> to the interface
-		<a href="#dfn-associated-interface">associated</a> to this factory method.
+	2. Let <var>option</var> be a dictionary of the type <a href="#associated-option-object">associated</a> to the interface
+		<a href="#associated-interface">associated</a> to this factory method.
 
 	3. For each parameter passed to the factory method, set the
 		dictionary member of the same name on <var>option</var> to the


### PR DESCRIPTION
The id for the associated interface and associated option object don't
include "dfn-".  Fix these in the href's.