### PR TITLE
Fix links to MediaElement and MediaStreamTrack

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2512,8 +2512,8 @@ is called on.
 
 	1. Let <var>o</var> be a new object of type <var>n</var>.
 
-	2. Let <var>option</var> be a dictionary of the type <a href="#associated-option-object">associated</a> to the interface
-		<a href="#associated-interface">associated</a> to this factory method.
+	2. Let <var>option</var> be a dictionary of the type <a href="#dfn-associated-option-object">associated</a> to the interface
+		<a href="#dfn-associated-interface">associated</a> to this factory method.
 
 	3. For each parameter passed to the factory method, set the
 		dictionary member of the same name on <var>option</var> to the

--- a/index.bs
+++ b/index.bs
@@ -225,9 +225,9 @@ The API supports these primary features:
 	to be split and merged.
 
 * Processing of audio sources from an <{audio}> or <{video}>
-	<a href="#mediaelementaudiosourcenode">media element</a>.
+	{{MediaElementAudioSourceNode|media element}}.
 
-* Processing live audio input using a <a href="#mediastreamtrackaudiosourcenode">MediaStream</a> from
+* Processing live audio input using a {{MediaStreamTrackAudioSourceNode|MediaStream}} from
 	getUserMedia().
 
 * Integration with WebRTC
@@ -1544,7 +1544,7 @@ Methods</h4>
 
 	: <dfn>createMediaElementSource(mediaElement)</dfn>
 	::
-		Creates a <a href="#mediaelementaudiosourcenode">MediaElementAudioSourceNode</a>
+		Creates a {{MediaElementAudioSourceNode}}
 		given an HTMLMediaElement. As a consequence of calling this
 		method, audio playback from the HTMLMediaElement will be
 		re-routed into the processing graph of the

--- a/index.bs
+++ b/index.bs
@@ -2512,8 +2512,8 @@ is called on.
 
 	1. Let <var>o</var> be a new object of type <var>n</var>.
 
-	2. Let <var>option</var> be a dictionary of the type <a href="#dfn-associated-option-object">associated</a> to the interface
-		<a href="#dfn-associated-interface">associated</a> to this factory method.
+	2. Let <var>option</var> be a dictionary of the type <a href="#associated-option-object">associated</a> to the interface
+		<a href="#associated-interface">associated</a> to this factory method.
 
 	3. For each parameter passed to the factory method, set the
 		dictionary member of the same name on <var>option</var> to the

--- a/index.bs
+++ b/index.bs
@@ -225,9 +225,9 @@ The API supports these primary features:
 	to be split and merged.
 
 * Processing of audio sources from an <{audio}> or <{video}>
-	<a href="#MediaElementAudioSourceNode">media element</a>.
+	<a href="#mediaelementaudiosourcenode">media element</a>.
 
-* Processing live audio input using a <a href="#MediaStreamTrackAudioSourceNode">MediaStream</a> from
+* Processing live audio input using a <a href="#mediastreamtrackaudiosourcenode">MediaStream</a> from
 	getUserMedia().
 
 * Integration with WebRTC
@@ -1544,7 +1544,7 @@ Methods</h4>
 
 	: <dfn>createMediaElementSource(mediaElement)</dfn>
 	::
-		Creates a <a href="#MediaElementAudioSourceNode">MediaElementAudioSourceNode</a>
+		Creates a <a href="#mediaelementaudiosourcenode">MediaElementAudioSourceNode</a>
 		given an HTMLMediaElement. As a consequence of calling this
 		method, audio playback from the HTMLMediaElement will be
 		re-routed into the processing graph of the


### PR DESCRIPTION
The hrefs for these elements should be all lower case, instead of camel case.