### PR TITLE
Fix some indentation errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7962,8 +7962,8 @@ Basic Waveform Phase</h4>
 
 The idealized mathematical waveforms for the various oscillator
 types are defined here. In summary, all waveforms are defined
-mathematically to be an odd function with a positive slope at time
-0. The actual waveforms produced by the oscillator may differ to
+mathematically to be an odd function with a positive slope at time 0.
+The actual waveforms produced by the oscillator may differ to
 prevent aliasing affects.
 
 The oscillator MUST produce the same result as if a PeriodicWave
@@ -8026,7 +8026,6 @@ basic waveforms.
 
 	This is extended to all \(t\) by using the fact that the
 	waveform is an odd function with period \(2\pi\).
-</dl>
 
 
 <!-- Big Text: Panner -->
@@ -8245,8 +8244,8 @@ Attributes</h4>
 	: <dfn>maxDistance</dfn>
 	::
 		The maximum distance between source and listener, after which the
-		volume will not be reduced any further. The default value is
-		10000. A {{RangeError}} exception MUST be thrown if this
+		volume will not be reduced any further. The default value is 10000.
+                A {{RangeError}} exception MUST be thrown if this
 		is set to a non-positive value.
 
 	: <dfn>orientationX</dfn>
@@ -9218,7 +9217,7 @@ instances created from the definition.
 	<a>parameterDescriptors</a> values. This internal storage is
 	populated when a promise from <a href="https://drafts.css-houdini.org/worklets/#dom-worklet-addmodule">addModule()</a>
 	on {{Window/audioWorklet}} gets resolved.
-</dl>
+
 
 <pre class="example" title="Registering an AudioWorkletProcessor class definition">
 // bypass.js script file, AudioWorkletGlobalScope


### PR DESCRIPTION
Fix some indentation errors:

* A couple of lines started with a number, fooling markdown into
  thinking a list was starting.  Move the number to the end of the
  previous line.
* Remove a couple of bare `</dl>` tags.

However, now Example 14 in the AudioWorklet Interface section is now
incorrectly indented, compared to the upstream spec version.  It's
indented as if it were part of the description for "node name to
parameter descriptor map", but it shouldn't be.