### PR TITLE
Fix links for queuing a control message

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1175,7 +1175,7 @@ Methods</h4>
 			5. Set the <em>control thread state</em> flag on the
 				{{BaseAudioContext}} to <code>running</code>.
 
-			6. <a href="#queuing">Queue a control message</a> to resume the {{BaseAudioContext}}.
+			6. <a>Queue a control message</a> to resume the {{BaseAudioContext}}.
 
 			7. Return <em>promise</em>.
 		</div>
@@ -1502,7 +1502,7 @@ Methods</h4>
 
 			4. Set the <em>control thread state</em> flag on the {{AudioContext}} to <code>closed</code>.
 
-			5. <a href="#queuing">Queue a control message</a> to the {{AudioContext}}.
+			5. <a>Queue a control message</a> to the {{AudioContext}}.
 
 			6. Return <em>promise</em>.
 		</div>
@@ -1688,7 +1688,7 @@ Methods</h4>
 
 			4. Set the <em>control thread state</em> flag on the {{AudioContext}} to <code>suspended</code>.
 
-			5. <a href="#queuing">Queue a control message</a> to suspend the {{AudioContext}}.
+			5. <a>Queue a control message</a> to suspend the {{AudioContext}}.
 
 			6. Return <em>promise</em>.
 		</div>
@@ -3846,7 +3846,7 @@ Methods</h4>
 			2. Check for any errors that must be thrown due to parameter
 				constraints described below.
 
-			3. <a href="#queuing">Queue a control message</a> to start the
+			3. <a>Queue a control message</a> to start the
 				{{AudioScheduledSourceNode}}, including the parameter
 				values in the messsage.
 		</div>
@@ -3881,7 +3881,7 @@ Methods</h4>
 			2. Check for any errors that must be thrown due to parameter
 				constraints described below.
 
-			3. <a href="#queuing">Queue a control message</a> to stop the
+			3. <a>Queue a control message</a> to stop the
 				{{AudioScheduledSourceNode}}, including the parameter
 				values in the messsage.
 		</div>
@@ -4494,7 +4494,7 @@ Methods</h4>
 			2. Check for any errors that must be thrown due to parameter
 				constraints described below.
 
-			3. <a href="#queuing">Queue a control message</a> to start the
+			3. <a>Queue a control message</a> to start the
 				{{AudioBufferSourceNode}}, including the parameter values
 				in the messsage.
 		</div>
@@ -4538,7 +4538,7 @@ Methods</h4>
 			2. Check for any errors that must be thrown due to parameter
 				constraints described below.
 
-			3. <a href="#queuing">Queue a control message</a> to stop the
+			3. <a>Queue a control message</a> to stop the
 				{{AudioBufferSourceNode}}, including the parameter values
 				in the messsage.
 		</div>
@@ -9920,7 +9920,7 @@ thread, where the constructor was called.
 
 	4. Set <var>node</var>'s {{AudioWorkletNode/parameters}} to <var>audioParamMap</var>.
 
-10. <a href="#queuing">Queue a control message</a> to create an
+10. <a>Queue a control message</a> to create an
 	{{AudioWorkletProcessor}}, given <var>nodeName</var>,
 	<var>processorPortSerialization</var>, and <var>node</var>.
 
@@ -10310,7 +10310,7 @@ queue</dfn>, that is a list of <dfn lt="control message">control
 messages</dfn> that are operations running on the <a>control
 thread</a>.
 
-<dfn id="queuing">Queuing a control message</dfn> means adding the
+<dfn id="queuing" lt="queue a control message">Queuing a control message</dfn> means adding the
 message to the end of the <a>control message queue</a> of an
 {{AudioContext}}.
 
@@ -10497,7 +10497,7 @@ can restart executing this algoritm if needed.
 		2. <a href="#computation-of-value">Compute the value(s)</a> of
 			this {{AudioParam}} for this block.
 
-		3. <a href="#queuing">Queue a control message</a> to set the
+		3. <a>Queue a control message</a> to set the
 			<var>[[current value]]</var> slot of this {{AudioParam}}
 			to the last value computed in the preceding step.
 

--- a/index.bs
+++ b/index.bs
@@ -1175,7 +1175,7 @@ Methods</h4>
 			5. Set the <em>control thread state</em> flag on the
 				{{BaseAudioContext}} to <code>running</code>.
 
-			6. <a href="#queue">Queue a control message</a> to resume the {{BaseAudioContext}}.
+			6. <a href="#queuing">Queue a control message</a> to resume the {{BaseAudioContext}}.
 
 			7. Return <em>promise</em>.
 		</div>
@@ -1502,7 +1502,7 @@ Methods</h4>
 
 			4. Set the <em>control thread state</em> flag on the {{AudioContext}} to <code>closed</code>.
 
-			5. <a href="#queue">Queue a control message</a> to the {{AudioContext}}.
+			5. <a href="#queuing">Queue a control message</a> to the {{AudioContext}}.
 
 			6. Return <em>promise</em>.
 		</div>
@@ -1688,7 +1688,7 @@ Methods</h4>
 
 			4. Set the <em>control thread state</em> flag on the {{AudioContext}} to <code>suspended</code>.
 
-			5. <a href="#queue">Queue a control message</a> to suspend the {{AudioContext}}.
+			5. <a href="#queuing">Queue a control message</a> to suspend the {{AudioContext}}.
 
 			6. Return <em>promise</em>.
 		</div>
@@ -3846,7 +3846,7 @@ Methods</h4>
 			2. Check for any errors that must be thrown due to parameter
 				constraints described below.
 
-			3. <a href="#queue">Queue a control message</a> to start the
+			3. <a href="#queuing">Queue a control message</a> to start the
 				{{AudioScheduledSourceNode}}, including the parameter
 				values in the messsage.
 		</div>
@@ -3881,7 +3881,7 @@ Methods</h4>
 			2. Check for any errors that must be thrown due to parameter
 				constraints described below.
 
-			3. <a href="#queue">Queue a control message</a> to stop the
+			3. <a href="#queuing">Queue a control message</a> to stop the
 				{{AudioScheduledSourceNode}}, including the parameter
 				values in the messsage.
 		</div>
@@ -4494,7 +4494,7 @@ Methods</h4>
 			2. Check for any errors that must be thrown due to parameter
 				constraints described below.
 
-			3. <a href="#queue">Queue a control message</a> to start the
+			3. <a href="#queuing">Queue a control message</a> to start the
 				{{AudioBufferSourceNode}}, including the parameter values
 				in the messsage.
 		</div>
@@ -4538,7 +4538,7 @@ Methods</h4>
 			2. Check for any errors that must be thrown due to parameter
 				constraints described below.
 
-			3. <a href="#queue">Queue a control message</a> to stop the
+			3. <a href="#queuing">Queue a control message</a> to stop the
 				{{AudioBufferSourceNode}}, including the parameter values
 				in the messsage.
 		</div>
@@ -10497,7 +10497,7 @@ can restart executing this algoritm if needed.
 		2. <a href="#computation-of-value">Compute the value(s)</a> of
 			this {{AudioParam}} for this block.
 
-		3. <a href="#queue">Queue a control message</a> to set the
+		3. <a href="#queuing">Queue a control message</a> to set the
 			<var>[[current value]]</var> slot of this {{AudioParam}}
 			to the last value computed in the preceding step.
 

--- a/index.bs
+++ b/index.bs
@@ -9751,7 +9751,7 @@ The return value of this method controls the lifetime of the
 the associated {{AudioWorkletProcessor}}'s <a>active
 source</a> flag. This in turn can affects whether subsequent
 invocations of <code>process()</code> occur and also the flag
-change is propagated by <a href="#queue">queueing a task</a> on
+change is propagated by queueing a task on
 the control thread to update the corresponding
 {{AudioWorkletNode}}'s <code>state</code> property
 accordingly.


### PR DESCRIPTION
The id is "#queuing", not "#queue" when referencing the section about
queuing a control message.

(I see that to upstream spec also has the same problem.)