### PR TITLE
Fix macro errors

### DIFF
--- a/audioparam.include
+++ b/audioparam.include
@@ -20,5 +20,5 @@
 		<tr>
 			<td>Rate
 			<td>[RATE]
-			<td>[RATE-NOTES]
+			<td>[RATE-NOTES?]
 </table>

--- a/index.bs
+++ b/index.bs
@@ -3630,7 +3630,7 @@ Methods</h4>
 		there is another automation event (if any).
 
 		An implicit call to {{AudioParam/setValueAtTime}} is made at time \(T_0 +
-		T_D\) with value \(V[N-1]\) so that following automations will
+		T_D\) with value \(V\[N-1]\) so that following automations will
 		start from the end of the {{AudioParam/setValueCurveAtTime}} event.
 
 		<pre class=argumentdef for="AudioParam/setValueCurveAtTime()">


### PR DESCRIPTION
* [RATE-NOTES] is optional.
* Escape [N-1], used in `\(V[N-1]\)`