### PR TITLE
Fix links to AudioWorklet and AnalyserNode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -25,9 +25,9 @@ Abstract: This specification describes a high-level Web <abbr title="Application
 	where a number of {{AudioNode}} objects are connected together to define the overall audio rendering.
 	The actual processing will primarily take place in the underlying implementation
 	(typically optimized Assembly / C / C++ code),
-	but [[#AudioWorklet|direct script processing and synthesis]] is also supported.
+	but [[#audioworklet|direct script processing and synthesis]] is also supported.
 
-	The [[#introduction|introductory]] section covers the motivation behind this specification.
+	The [[#introductory]] section covers the motivation behind this specification.
 
 	This API is designed to be used in conjunction with other APIs and elements on the web platform, notably:
 	XMLHttpRequest [[XHR]] (using the <code>responseType</code> and <code>response</code> attributes).
@@ -239,7 +239,7 @@ The API supports these primary features:
 		peer using a {{MediaStreamAudioDestinationNode}}
 		and [[!webrtc]].
 
-* Audio stream synthesis and processing <a href="#AudioWorklet">directly using scripts</a>.
+* Audio stream synthesis and processing [[#audioworklet|directly using scripts]].
 
 * <a href="#Spatialization">Spatialized audio</a> supporting a wide
 	range of 3D games and immersive environments:
@@ -269,7 +269,7 @@ The API supports these primary features:
 
 * Dynamics compression for overall control and sweetening of the mix
 
-* Efficient <a href="#the-analysernode-interface">real-time time-domain and frequency analysis / music visualizer support</a>
+* Efficient [[#analysernode|real-time time-domain and frequency analysis / music visualizer support]].
 
 * Efficient biquad filters for lowpass, highpass, and other common filters.
 


### PR DESCRIPTION
The links just needed to be downcased or changed from an href.