### PR TITLE
Fix links to AudioParamMap, ChannelInterpretation, and DistanceModelType

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9892,7 +9892,7 @@ thread, where the constructor was called.
 9. Let <var>parameterDescriptors</var> be the result of retrieval
 	of <var>nodeName</var> from <a>node name to parameter descriptor map</a>:
 
-	1. Let <var>audioParamMap</var> be a new <a>AudioParamMap</a> object.
+	1. Let <var>audioParamMap</var> be a new {{AudioParamMap}} object.
 
 	2. For each <var>descriptor</var> of <var>parameterDescriptors</var>:
 		1. Let <var>paramName</var> be the value of
@@ -10860,7 +10860,7 @@ MUST:
 
 	1. up-mix or down-mix the connection to
 		<a>computedNumberOfChannels</a> according to the
-		{{ChannelInterpretation/ChannelInterpretation}}
+		{{ChannelInterpretation}}
 		value given by the node's {{AudioNode/channelInterpretation}} attribute.
 
 	2. Mix it together with all of the other mixed streams (from other
@@ -11331,9 +11331,9 @@ function distance(panner) {
 
 <em>distance</em> will then be used to calculate
 <em>distanceGain</em> which depends on the <em>distanceModel</em>
-attribute. See the {{DistanceModelType/DistanceModelType}} section for details of how
+attribute. See the {{DistanceModelType}} section for details of how
 this is calculated for each distance model. The value computed by the
-{{DistanceModelType/DistanceModelType}} equations
+{{DistanceModelType}} equations
 are to be clamped to [0, 1].
 
 As part of its processing, the {{PannerNode}}


### PR DESCRIPTION
Fix the links to these:
* AudioParamMap updated from `<a>` to `{{`
* The others just needed to be changed from `{{foo/foo}}` to just
  `{{foo}}`.