### PR TITLE
Fix more target anchor errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2512,8 +2512,8 @@ is called on.
 
 	1. Let <var>o</var> be a new object of type <var>n</var>.
 
-	2. Let <var>option</var> be a dictionary of the type <a href="#associated-option-object">associated</a> to the interface
-		<a href="#associated-interface">associated</a> to this factory method.
+	2. Let <var>option</var> be a dictionary of the type [[#associated-option-object|associated]] to the interface
+		[[#associated-interface|associated]] to this factory method.
 
 	3. For each parameter passed to the factory method, set the
 		dictionary member of the same name on <var>option</var> to the

--- a/index.bs
+++ b/index.bs
@@ -2512,8 +2512,8 @@ is called on.
 
 	1. Let <var>o</var> be a new object of type <var>n</var>.
 
-	2. Let <var>option</var> be a dictionary of the type [[#associated-option-object|associated]] to the interface
-		[[#associated-interface|associated]] to this factory method.
+	2. Let <var>option</var> be a dictionary of the type <a lt="associated option object">associated</a> to the interface
+		<a lt="associated interface">associated</a> to this factory method.
 
 	3. For each parameter passed to the factory method, set the
 		dictionary member of the same name on <var>option</var> to the

--- a/index.bs
+++ b/index.bs
@@ -2512,8 +2512,8 @@ is called on.
 
 	1. Let <var>o</var> be a new object of type <var>n</var>.
 
-	2. Let <var>option</var> be a dictionary of the type <a href="#dfn-associated-option-object">associated</a> to the interface
-		<a href="#dfn-associated-interface">associated</a> to this factory method.
+	2. Let <var>option</var> be a dictionary of the type <a href="#associated-option-object">associated</a> to the interface
+		<a href="#associated-interface">associated</a> to this factory method.
 
 	3. For each parameter passed to the factory method, set the
 		dictionary member of the same name on <var>option</var> to the
@@ -7013,7 +7013,7 @@ quantum of audio.
 
 	5. Clamp <var>detector average</var> to a maximum of 1.0.
 
-	6. Let <var>envelope rate</var> be the result of <a href="#envelope-rate">computing the envelope rate</a>.
+	6. Let <var>envelope rate</var> be the result of <a>computing the envelope rate</a>.
 
 	7. If <var>releasing</var> is `true`, set
 		<var>compressor gain</var> to the multiplication of
@@ -7065,7 +7065,7 @@ the compressor so it is comparable to the input level.
 </div>
 
 <div algorithm>
-	<dfn id="#envelope-rate">Computing the envelope rate</dfn> is done
+	<dfn>Computing the envelope rate</dfn> is done
 	by applying a function to the ratio of the <var>compressor
 	gain</var> and the <var>detector average</var>. User-agents are
 	allowed to choose the shape the envelope function. However, this


### PR DESCRIPTION
* Remove the "#dfn-" from #dfn-associated-option-object changed and
  #dfn-associated-interface.
* Use correct link/dfn for computing the envelope rate.