### PR TITLE
Fix typo Audiobuffer/copyFromChannel

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2235,7 +2235,7 @@ Methods</h4>
 		remaining elements of <code>destination</code> are not
 		modified.
 
-		<pre class=argumentdef for="Audiobuffer/copyFromChannel()">
+		<pre class=argumentdef for="AudioBuffer/copyFromChannel()">
 		destination: The array the channel data will be copied to.
 		channelNumber: The index of the channel to copy the data from. If <code>channelNumber</code> is greater or equal than the number of channel of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
 		startInChannel: An optional offset to copy the data from. If <code>startInChannel</code> is greater than the <code>length</code> of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.


### PR DESCRIPTION
The method is "AudioBuffer/copyFromChannel()"; it's a "AudioBuffer",
not "Audiobuffer".