### PR TITLE
Fix tail-time-notes and WaveShaperNode

### DIFF
--- a/audionode.include
+++ b/audionode.include
@@ -28,5 +28,5 @@
 		<tr>
 			<td><a>tail-time</a> reference
 			<td>[TAIL-TIME]
-			<td>[TIME-TIME-NOTES?]
+			<td>[TAIL-TIME-NOTES?]
 </table>

--- a/index.bs
+++ b/index.bs
@@ -9106,7 +9106,7 @@ Attributes</h4>
 				attribute.
 		</div>
 
-	: <dfn>overSample</dfn>
+	: <dfn>oversample</dfn>
 	::
 		Specifies what type of oversampling (if any) should be used
 		when applying the shaping curve. The default value is "none",


### PR DESCRIPTION
* Fix typo in audionode.include
* The WaveShaperNode attribute oversample is "s", not "S".