### PR TITLE
Fix issues about multiple possible idl refs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2226,11 +2226,11 @@ Methods</h4>
 		the specified channel of the {{AudioBuffer}} to the
 		<code>destination</code> array.
 
-		Let {{buffer}} be the {{AudioBuffer}} buffer with
+		Let {{AudioBufferSourceNode/buffer}} be the {{AudioBuffer}} buffer with
 		\(N_b\) frames, let \(N_f\) be the number of elements in the
 		<code>destination</code> array, and \(k\) be the value of
 		<code>startInChannel</code>. Then the number of frames copied
-		from {{buffer}} to <code>destination</code> is
+		from {{AudioBufferSourceNode/buffer}} to <code>destination</code> is
 		\(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
 		remaining elements of <code>destination</code> are not
 		modified.
@@ -2251,11 +2251,11 @@ Methods</h4>
 		the specified channel of the {{AudioBuffer}} to the
 		<code>destination</code> array.
 
-		Let {{buffer}} be the {{AudioBuffer}} buffer with
+		Let {{AudioBufferSourceNode/buffer}} be the {{AudioBuffer}} buffer with
 		\(N_b\) frames, let \(N_f\) be the number of elements in the
 		<code>destination</code> array, and \(k\) be the value of
 		<code>startInChannel</code>. Then the number of frames copied
-		from {{buffer}} to <code>destination</code> is
+		from {{AudioBufferSourceNode/buffer}} to <code>destination</code> is
 		\(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
 		remaining elements of <code>destination</code> are not
 		modified.
@@ -2328,19 +2328,19 @@ The [=acquire the contents of an AudioBuffer=] operation is invoked in the follo
 
 * When <code>AudioBufferSourceNode.start</code> is called, it
 	<a href="#acquire-the-content">acquires the contents</a> of the
-	node's {{buffer}}. If the operation fails, nothing is
+	node's {{AudioBufferSourceNode/buffer}}. If the operation fails, nothing is
 	played.
 
-* When the {{buffer}} of an {{AudioBufferSourceNode}}
+* When the {{AudioBufferSourceNode/buffer}} of an {{AudioBufferSourceNode}}
 	is set and <code>AudioBufferSourceNode.start</code> has been
 	previously called, the setter <a href="#acquire-the-content">acquires
 	the content</a> of the {{AudioBuffer}}. If the operation fails,
 	nothing is played.
 
-* When a {{ConvolverNode}}'s {{buffer}} is set to an
+* When a {{ConvolverNode}}'s {{ConvolverNode/buffer}} is set to an
 	{{AudioBuffer}} while the node is connected to an output node, or
 	a {{ConvolverNode}} is connected to an output node while the
-	{{ConvolverNode}}'s {{buffer}} is set to an
+	{{ConvolverNode}}'s {{ConvolverNode/buffer}} is set to an
 	{{AudioBuffer}}, it <a href="#acquire-the-content">acquires the
 	content</a> of the {{AudioBuffer}}.
 
@@ -2554,8 +2554,8 @@ is called on.
 		steps, with <var>k</var> the key of the member, and <var>v</var>
 		its value:
 
-		1. If <var>k</var> is {{disableNormalization}} or
-			{{buffer}} and <var>n</var> is {{ConvolverNode}},
+		1. If <var>k</var> is {{ConvolverOptions/disableNormalization}} or
+			{{ConvolverOptions/buffer}} and <var>n</var> is {{ConvolverNode}},
 			jump to the beginning of this loop.
 
 		2. If <var>k</var> is the name of an {{AudioParam}} on this

--- a/index.bs
+++ b/index.bs
@@ -3822,7 +3822,7 @@ Attributes</h4>
 		<code>onended</code> event is dispatched when the stop time
 		determined by {{AudioScheduledSourceNode/stop()}} is reached.
 		For an {{AudioBufferSourceNode}}, the event is
-		also dispatched because the {{AudioBufferSourceNode/duration}} has been
+		also dispatched because the {{duration!!argument}} has been
 		reached or if the entire {{AudioBufferSourceNode/buffer}} has been
 		played.
 </dl>
@@ -4332,7 +4332,7 @@ A <dfn>playhead position</dfn> for an {{AudioBufferSourceNode}} is
 defined as any quantity representing a time offset in seconds,
 relative to the time coordinate of the first sample frame in the
 buffer. Such values are to be considered independently from the
-node's <code>playbackRate</code> and {{detune}} parameters.
+node's <code>playbackRate</code> and {{AudioBufferSourceNode/detune}} parameters.
 In general, playhead positions may be subsample-accurate and need not
 refer to exact sample frame positions. They may assume valid values
 between 0 and the duration of the buffer.
@@ -4509,7 +4509,7 @@ Methods</h4>
 		<pre class=argumentdef for="AudioBufferSourceNode/start()">
 			when: The <code>when</code> parameter describes at what time (in seconds) the sound should start playing. It is in the same time coordinate system as the {{AudioContext}}'s {{BaseAudioContext/currentTime}} attribute. If 0 is passed in for this value or if the value is less than <b>currentTime</b>, then the sound will start playing immediately. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>when</code> is negative.</span>
 			offset: The <code>offset</code> parameter supplies a <a>playhead position</a> where playback will begin. If 0 is passed in for this value, then playback will start from the beginning of the buffer. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>offset</code> is negative.</span> If <code>offset</code> is greater than {{AudioBufferSourceNode/loopEnd}}, playback will begin at {{AudioBufferSourceNode/loopEnd}} (and immediately loop to {{AudioBufferSourceNode/loopStart}}). <code>offset</code> is silently clamped to [0, <code>duration</code>], when <code>startTime</code> is reached, where <code>duration</code> is the value of the <code>duration</code> attribute of the {{AudioBuffer}} set to the {{buffer}} attribute of this <code>AudioBufferSourceNode</code>.
-			duration: The {{duration}} parameter describes the duration of the sound (in seconds) to be played. If this parameter is passed, this method has exactly the same effect as the invocation of <code>start(when, offset)</code> followed by <code>stop(when + duration)</code>. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>duration</code> is negative.</span>
+			duration: The {{duration!!argument}} parameter describes the duration of the sound (in seconds) to be played. If this parameter is passed, this method has exactly the same effect as the invocation of <code>start(when, offset)</code> followed by <code>stop(when + duration)</code>. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>duration</code> is negative.</span>
 		</pre>
 
 		<div>

--- a/index.bs
+++ b/index.bs
@@ -982,9 +982,9 @@ Methods</h4>
 				<code>imag</code> parameters passed to this factory method to
 				the attributes of the same name on <var>o</var>.
 
-			4. Set the {{disableNormalization}} attribute on
+			4. Set the {{PeriodicWaveConstraints/disableNormalization}} attribute on
 				<var>o</var> to the value of the
-				{{disableNormalization}} attribute of the
+				{{PeriodicWaveConstraints/disableNormalization}} attribute of the
 				<code>constraints</code> attribute passed to the factory
 				method.
 
@@ -1010,7 +1010,7 @@ Methods</h4>
 		This method is DEPRECATED, as it is intended to be replaced by {{AudioWorkletNode}}.
 		Creates a {{ScriptProcessorNode}} for direct audio processing using scripts.
 		<span class="synchronous">An {{IndexSizeError}} exception MUST be thrown if
-		{{bufferSize}} or {{numberOfInputChannels}} or {{numberOfOutputChannels}}
+		{{bufferSize!!argument}} or {{numberOfInputChannels}} or {{numberOfOutputChannels}}
 		are outside the valid range.</span>
 
 		It is invalid for both {{numberOfInputChannels}} and {{numberOfOutputChannels}} to be zero.
@@ -8223,14 +8223,14 @@ Attributes</h4>
 	::
 		A parameter for directional audio sources, this is an angle, in
 		degrees, outside of which the volume will be reduced to a
-		constant value of {{coneOuterGain}}. The default
+		constant value of {{PannerNode/coneOuterGain}}. The default
 		value is 360. The behavior is undefined if the angle is outside
 		the interval [0, 360].
 
 	: <dfn>coneOuterGain</dfn>
 	::
 		A parameter for directional audio sources, this is the gain
-		outside of the {{coneOuterAngle}}. The default
+		outside of the {{PannerNode/coneOuterAngle}}. The default
 		value is 0. It is a linear value (not dB) in the range [0, 1]. An
 		{{InvalidStateError}} MUST be thrown if the parameter is
 		outside this range.

--- a/index.bs
+++ b/index.bs
@@ -6642,7 +6642,7 @@ Attributes</h4>
 		{{AudioContext}} method {{createDelay()}}.
 
 		If {{DelayNode}} is part of a <a>cycle</a>,
-		then the value of the {{delayTime}} attribute
+		then the value of the {{DelayNode/delayTime}} attribute
 		is clamped to a minimum of one <a>render quantum</a>.
 
 		<pre class=include>

--- a/index.bs
+++ b/index.bs
@@ -4397,7 +4397,7 @@ Attributes</h4>
 			To set the {{AudioBufferSourceNode/buffer}} attribute, execute these steps:
 
 			1. Let <code>new buffer</code> be the {{AudioBuffer}} or
-				<code>null</code> value to be assigned to {{buffer}}.
+				<code>null</code> value to be assigned to {{AudioBufferSourceNode/buffer}}.
 
 			2. If <code>new buffer</code> is not <code>null</code> and
 				<var>[[buffer set]]</var> is true, throw an
@@ -4406,12 +4406,12 @@ Attributes</h4>
 			3. If <code>new buffer</code> is not <code>null</code>, set
 				<var>[[buffer set]]</var> to true.
 
-			4. Assign <code>new buffer</code> to the {{buffer}}
+			4. Assign <code>new buffer</code> to the {{AudioBufferSourceNode/buffer}}
 				attribute.
 
 			5. If <code>start()</code> has previously been called on this
 				node, perform the operation <a href="#acquire-the-content">acquire the content</a> on
-				{{buffer}}.
+				{{AudioBufferSourceNode/buffer}}.
 		</div>
 
 	: <dfn>detune</dfn>
@@ -4508,7 +4508,7 @@ Methods</h4>
 
 		<pre class=argumentdef for="AudioBufferSourceNode/start()">
 			when: The <code>when</code> parameter describes at what time (in seconds) the sound should start playing. It is in the same time coordinate system as the {{AudioContext}}'s {{BaseAudioContext/currentTime}} attribute. If 0 is passed in for this value or if the value is less than <b>currentTime</b>, then the sound will start playing immediately. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>when</code> is negative.</span>
-			offset: The <code>offset</code> parameter supplies a <a>playhead position</a> where playback will begin. If 0 is passed in for this value, then playback will start from the beginning of the buffer. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>offset</code> is negative.</span> If <code>offset</code> is greater than {{AudioBufferSourceNode/loopEnd}}, playback will begin at {{AudioBufferSourceNode/loopEnd}} (and immediately loop to {{AudioBufferSourceNode/loopStart}}). <code>offset</code> is silently clamped to [0, <code>duration</code>], when <code>startTime</code> is reached, where <code>duration</code> is the value of the <code>duration</code> attribute of the {{AudioBuffer}} set to the {{buffer}} attribute of this <code>AudioBufferSourceNode</code>.
+			offset: The <code>offset</code> parameter supplies a <a>playhead position</a> where playback will begin. If 0 is passed in for this value, then playback will start from the beginning of the buffer. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>offset</code> is negative.</span> If <code>offset</code> is greater than {{AudioBufferSourceNode/loopEnd}}, playback will begin at {{AudioBufferSourceNode/loopEnd}} (and immediately loop to {{AudioBufferSourceNode/loopStart}}). <code>offset</code> is silently clamped to [0, <code>duration</code>], when <code>startTime</code> is reached, where <code>duration</code> is the value of the <code>duration</code> attribute of the {{AudioBuffer}} set to the {{AudioBufferSourceNode/buffer}} attribute of this <code>AudioBufferSourceNode</code>.
 			duration: The {{duration!!argument}} parameter describes the duration of the sound (in seconds) to be played. If this parameter is passed, this method has exactly the same effect as the invocation of <code>start(when, offset)</code> followed by <code>stop(when + duration)</code>. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>duration</code> is negative.</span>
 		</pre>
 
@@ -4585,7 +4585,7 @@ Dictionary {{AudioBufferSourceOptions}} Members</h5>
 	: <dfn>buffer</dfn>
 	::
 		The audio asset to be played. This is equivalent to assigning
-		{{buffer}} to the {{AudioBufferSourceNode/buffer}} attribute of
+		{{AudioBufferSourceOptions/buffer}} to the {{AudioBufferSourceNode/buffer}} attribute of
 		the {{AudioBufferSourceNode}}.
 
 	: <dfn>detune</dfn>
@@ -6373,17 +6373,17 @@ Attributes</h4>
 		{{AudioBuffer}} MUST be of the same sample-rate
 		as the {{AudioContext}} or a
 		{{NotSupportedError}} exception MUST be thrown</span>.
-		At the time when this attribute is set, the {{buffer}} and
+		At the time when this attribute is set, the {{ConvolverNode/buffer}} and
 		the state of the {{normalize}} attribute will be used to
 		configure the {{ConvolverNode}} with this
 		impulse response having the given normalization. The initial
 		value of this attribute is null.
 
 		<div algorithm="ConvolverNode.buffer">
-			To set the {{buffer}} attribute, execute these steps:
+			To set the {{ConvolverNode/buffer}} attribute, execute these steps:
 
 			1. Let <code>new buffer</code> be the {{AudioBuffer}} to be
-				assigned to {{buffer}}.
+				assigned to {{ConvolverNode/buffer}}.
 
 			2. If <code>new buffer</code> is not <code>null</code> and
 				<var>[[buffer set]]</var> is true, <span class="synchronous">throw an {{InvalidStateError}} and abort
@@ -6392,7 +6392,7 @@ Attributes</h4>
 			3. If <code>new buffer</code> is not <code>null</code>, set
 				<var>[[buffer set]]</var> to true.
 
-			4. Assign <code>new buffer</code> to the {{buffer}}
+			4. Assign <code>new buffer</code> to the {{ConvolverNode/buffer}}
 				attribute.
 		</div>
 
@@ -6402,8 +6402,8 @@ Attributes</h4>
 
 		The {{ConvolverNode}} only produces a mono output in the
 		single case where there is a single input channel and a
-		single-channel {{buffer}}. In all other cases, the
-		output is stereo. In particular, when the {{buffer}}
+		single-channel {{ConvolverNode/buffer}}. In all other cases, the
+		output is stereo. In particular, when the {{ConvolverNode/buffer}}
 		has four channels and there are two input channels, the
 		{{ConvolverNode}} performs matrix "true" stereo convolution.
 
@@ -6411,26 +6411,26 @@ Attributes</h4>
 	::
 		Controls whether the impulse response from the buffer will be
 		scaled by an equal-power normalization when the
-		{{buffer}} atttribute is set. Its default value is
+		{{ConvolverNode/buffer}} atttribute is set. Its default value is
 		`true` in order to achieve a more uniform output
 		level from the convolver when loaded with diverse impulse
 		responses. If {{normalize}} is set to
 		<code>false</code>, then the convolution will be rendered with
 		no pre-processing/scaling of the impulse response. Changes to
 		this value do not take effect until the next time the
-		{{buffer}} attribute is set.
+		{{ConvolverNode/buffer}} attribute is set.
 
 		If the {{normalize}} attribute is false when the
-		{{buffer}} attribute is set then the
+		{{ConvolverNode/buffer}} attribute is set then the
 		{{ConvolverNode}} will perform a linear
 		convolution given the exact impulse response contained within
-		the {{buffer}}.
+		the {{ConvolverNode/buffer}}.
 
 		Otherwise, if the {{normalize}} attribute is true when the
-		{{buffer}} attribute is set then the
+		{{ConvolverNode/buffer}} attribute is set then the
 		{{ConvolverNode}} will first perform a scaled
 		RMS-power analysis of the audio data contained within
-		{{buffer}} to calculate a <var>normalizationScale</var>
+		{{ConvolverNode/buffer}} to calculate a <var>normalizationScale</var>
 		given this algorithm:
 
 		<pre>
@@ -6484,7 +6484,7 @@ Attributes</h4>
 		calculated <var>normalizationScale</var> value and multiply it by
 		the result of the linear convolution resulting from processing
 		the input with the impulse response (represented by the
-		{{buffer}}) to produce the final output. Or any
+		{{ConvolverNode/buffer}}) to produce the final output. Or any
 		mathematically equivalent operation may be used, such as
 		pre-multiplying the input by <var>normalizationScale</var>, or
 		pre-multiplying a version of the impulse-response by

--- a/index.bs
+++ b/index.bs
@@ -6213,7 +6213,7 @@ This interface represents a constant audio source whose output is
 nominally a constant value. It is useful as a constant source node in
 general and can be used as if it were a constructible
 {{AudioParam}} by automating its
-{{offset}} or connecting another node to it.
+{{ConstantSourceNode/offset}} or connecting another node to it.
 
 The single output of this node consists of one channel (mono).
 

--- a/index.bs
+++ b/index.bs
@@ -2346,7 +2346,7 @@ The [=acquire the contents of an AudioBuffer=] operation is invoked in the follo
 
 * When the dispatch of an <a>AudioProcessingEvent</a> completes, it
 	<a href="#acquire-the-content">acquires the contents</a> of its
-	{{outputBuffer}}.
+	{{AudioProcessingEvent/outputBuffer}}.
 
 Note: This means that {{AudioBuffer/copyToChannel()}} cannot be used to change
 the content of an {{AudioBuffer}} currently in use by an
@@ -5344,7 +5344,7 @@ The event handler processes audio from the input (if any) by
 accessing the audio data from the <code>inputBuffer</code> attribute.
 The audio data which is the result of the processing (or the
 synthesized data if there are no inputs) is then placed into the
-{{outputBuffer}}.
+{{AudioProcessingEvent/outputBuffer}}.
 
 <pre class="idl">
 [Exposed=Window,

--- a/index.bs
+++ b/index.bs
@@ -9074,9 +9074,9 @@ Attributes</h4>
 		to its output without modification.
 
 		Values of the curve are spread with equal spacing in the [-1;
-		1] range. This means that a {{curve}} with a
+		1] range. This means that a {{WaveShaperNode/curve}} with a
 		even number of value will not have a value for a signal at
-		zero, and a {{curve}} with an odd number of
+		zero, and a {{WaveShaperNode/curve}} with an odd number of
 		value will have a value for a signal at zero.
 
 		A {{InvalidStateError}} MUST be thrown if this

--- a/index.bs
+++ b/index.bs
@@ -6513,7 +6513,7 @@ Dictionary {{ConvolverOptions}} Members</h5>
 	::
 		The desired buffer for the {{ConvolverNode}}.
 		This buffer will be normalized according to the value of
-		{{disableNormalization}}.
+		{{ConvolverOptions/disableNormalization}}.
 
 	: <dfn>disableNormalization</dfn>
 	::

--- a/index.bs
+++ b/index.bs
@@ -5292,14 +5292,14 @@ Methods</h4>
 	: <dfn>setPosition(x, y, z)</dfn>
 	::
 		This method is DEPRECATED. It is equivalent to setting
-		{{positionX}}.{{AudioParam/value}},
-		{{positionY}}.{{AudioParam/value}}, and
-		{{positionZ}}.{{AudioParam/value}}
+		{{AudioListener/positionX}}.{{AudioParam/value}},
+		{{AudioListener/positionY}}.{{AudioParam/value}}, and
+		{{AudioListener/positionZ}}.{{AudioParam/value}}
 		directly with the given <code>x</code>, <code>y</code>, and
 		<code>z</code> values, respectively.
 
-		Consequently, any of the {{positionX}}, {{positionY}},
-		and {{positionZ}} {{AudioParam}}s for this
+		Consequently, any of the {{AudioListener/positionX}}, {{AudioListener/positionY}},
+		and {{AudioListener/positionZ}} {{AudioParam}}s for this
 		{{AudioListenerNode}} have an automation curve set using
 		{{AudioParam/setValueCurveAtTime()}} at the time
 		this method is called, a {{NotSupportedError}} MUST be

--- a/index.bs
+++ b/index.bs
@@ -5667,7 +5667,7 @@ Attributes</h4>
 	: <dfn>detune</dfn>
 	::
 		A detune value, in cents, for the frequency. It forms a
-		<a>compound parameter</a> with {{frequency}}.
+		<a>compound parameter</a> with {{BiquadFilterNode/frequency}}.
 
 		<pre class=include>
 		path: audioparam.include
@@ -5684,7 +5684,7 @@ Attributes</h4>
 	::
 		The frequency at which the {{BiquadFilterNode}}
 		will operate, in Hz. It forms a <a>compound parameter</a> with
-		{{detune}}.
+		{{BiquadFilterNode/detune}}.
 
 		<pre class=include>
 		path: audioparam.include
@@ -5773,16 +5773,16 @@ Dictionary {{BiquadFilterOptions}} Members</h5>
 
 <dl dfn-type=dict-member dfn-for="BiquadFilterOptions">
 	: <dfn>Q</dfn>
-	:: The desired initial value for {{Q}}.
+	:: The desired initial value for {{BiquadFilterNode/Q}}.
 
 	: <dfn>detune</dfn>
-	:: The desired initial value for {{detune}}.
+	:: The desired initial value for {{BiquadFilterNode/detune}}.
 
 	: <dfn>frequency</dfn>
-	:: The desired initial value for {{frequency}}.
+	:: The desired initial value for {{BiquadFilterNode/frequency}}.
 
 	: <dfn>gain</dfn>
-	:: The desired initial value for {{gain}}.
+	:: The desired initial value for {{BiquadFilterNode/gain}}.
 
 	: <dfn>type</dfn>
 	:: The desired initial type of the filter.
@@ -7778,7 +7778,7 @@ It is expected that an implementation will take some care in
 achieving this ideal, but it is reasonable to consider lower-quality,
 less-costly approaches on lower-end hardware.
 
-Both {{frequency}} and {{detune}} are <a>a-rate</a>
+Both {{OscillatorNode/frequency}} and {{Oscillator/detune}} are <a>a-rate</a>
 parameters, and form a <a>compound parameter</a>. They are used
 together to determine a <dfn>computedOscFrequency</dfn> value:
 
@@ -7853,9 +7853,9 @@ Attributes</h4>
 	: <dfn>detune</dfn>
 	::
 		A detuning value (in cents) which will offset the
-		{{frequency}} by the given amount. Its default
+		{{OscillatorNode/frequency}} by the given amount. Its default
 		<code>value</code> is 0. This parameter is <a>a-rate</a>. It
-		forms a <a>compound parameter</a> with {{frequency}}
+		forms a <a>compound parameter</a> with {{OscillatorNode/frequency}}
 		to form the <a>computedOscFrequency</a>.
 
 		<pre class=include>
@@ -7873,7 +7873,7 @@ Attributes</h4>
 	::
 		The frequency (in Hertz) of the periodic waveform. Its default
 		<code>value</code> is 440. This parameter is <a>a-rate</a>. It
-		forms a <a>compound parameter</a> with {{detune}} to
+		forms a <a>compound parameter</a> with {{OscillatorNode/detune}} to
 		form the <a>computedOscFrequency</a>. Its <a>nominal range</a>
 		is [-<a>Nyquist frequency</a>, <a>Nyquist frequency</a>].
 


### PR DESCRIPTION
Use correct links for ambiguous idl refs, basically adding the correct node types to the links.

Not all issues are fixed, but most of the most obvious ones are.