### PR TITLE
Fix typo: setOrientation should be setPosition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5314,7 +5314,7 @@ Methods</h4>
 
 		The default value is (0,0,0).
 
-		<pre class=argumentdef for="AudioListener/setOrientation()">
+		<pre class=argumentdef for="AudioListener/setPosition()">
 			x:
 			y:
 			z:


### PR DESCRIPTION
Fixes fatal error about x,y,z being defined more than once.