### PR TITLE
Fix typo in argumentdef for disconnect

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3003,7 +3003,7 @@ Methods</h4>
 		goes to 0 when this operation takes effect. The intrinsic
 		parameter value is not affected by this operation.
 
-		<pre class=argumentdef for="AudioNode/AudioNode(destinationParam)">
+		<pre class=argumentdef for="AudioNode/disconnect(destinationParam)">
 			destinationParam: The <code>destinationParam</code> parameter is the {{AudioParam}} to disconnect. <span class="synchronous">If there is no connection to the <code>destinationParam</code>, an {{InvalidAccessError}} exception MUST be thrown.</span>
 		</pre>
 


### PR DESCRIPTION
Was AudioNode/AudioNode(destinationParam) but should be
AudioNode/disconnect(destinationParam)
