### PR TITLE
Fix links in decode audio data

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1130,8 +1130,8 @@ Methods</h4>
 
 					2. Resolve <var>promise</var> with <var>buffer</var>.
 
-					3. If <dfn>successCallback</dfn> is not missing,
-						invoke <a>successCallback</a> with <var>buffer</var>.
+					3. If {{BaseAudioContext/decodeAudioData()/successCallback!!argument}} is not missing,
+						invoke {{BaseAudioContext/decodeAudioData()/successCallback!!argument}} with <var>buffer</var>.
 		</div>
 
 		<pre class=argumentdef for="BaseAudioContext/decodeAudioData()">

--- a/index.bs
+++ b/index.bs
@@ -1113,7 +1113,7 @@ Methods</h4>
 
 				2. Reject <var>promise</var> with <var>error</var>.
 
-				3. If {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} is not missing, invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument} with <var>error</var>.
+				3. If {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} is not missing, invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with <var>error</var>.
 
 			3. Otherwise:
 				1. Take the result, representing the decoded linear PCM

--- a/index.bs
+++ b/index.bs
@@ -1077,7 +1077,7 @@ Methods</h4>
 				<code>false</code>, execute the following steps:
 
 				1. <a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a>
-						the {{BaseAudioContext/decodeAudioData()/audioData!!argument}} {{ArrayBuffer}}. This
+						the {{audioData}} {{ArrayBuffer}}. This
 						operation is described in [[!ECMASCRIPT]].
 				2. Queue a decoding operation to be performed on another thread.
 
@@ -1099,7 +1099,7 @@ Methods</h4>
 			Note: Multiple <em>decoding threads</em> can run in parallel to
 			service multiple calls to <code>decodeAudioData</code>.
 
-			1. Attempt to decode the encoded {{BaseAudioContext/decodeAudioData()/audioData!!argument}} into linear
+			1. Attempt to decode the encoded {{audioData}} into linear
 				PCM.
 
 			2. If a decoding error is encountered due to the audio format
@@ -1119,7 +1119,7 @@ Methods</h4>
 				1. Take the result, representing the decoded linear PCM
 					audio data, and resample it to the sample-rate of the
 					{{AudioContext}} if it is different from
-					the sample-rate of {{BaseAudioContext/decodeAudioData()/audioData!!argument}}.
+					the sample-rate of {{audioData}}.
 
 				2. Queue a task on the <a>control thread</a>'s event loop
 					to execute the following steps:

--- a/index.bs
+++ b/index.bs
@@ -1073,11 +1073,11 @@ Methods</h4>
 			1. Let <var>promise</var> be a new promise.
 
 			2. If the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
-				(described in [[!ECMASCRIPT]]) on <a>audioData</a> is
+				(described in [[!ECMASCRIPT]]) on {{BaseAudioContext/decodeAudioData()/audioData!!argument}} is
 				<code>false</code>, execute the following steps:
 
 				1. <a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a>
-						the <a>audioData</a> {{ArrayBuffer}}. This
+						the {{BaseAudioContext/decodeAudioData()/audioData!!argument}} {{ArrayBuffer}}. This
 						operation is described in [[!ECMASCRIPT]].
 				2. Queue a decoding operation to be performed on another thread.
 
@@ -1085,7 +1085,7 @@ Methods</h4>
 
 				1. Let <var>error</var> be a <code>DataCloneError</code>.
 				2. Reject <var>promise</var> with <var>error</var>.
-				3. Queue a task to invoke <a>errorCallback</a> with <var> error</var>.
+				3. Queue a task to invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with <var>error</var>.
 
 			4. Return <var>promise</var>.
 		</div>
@@ -1099,7 +1099,7 @@ Methods</h4>
 			Note: Multiple <em>decoding threads</em> can run in parallel to
 			service multiple calls to <code>decodeAudioData</code>.
 
-			1. Attempt to decode the encoded <a>audioData</a> into linear
+			1. Attempt to decode the encoded {{BaseAudioContext/decodeAudioData()/audioData!!argument}} into linear
 				PCM.
 
 			2. If a decoding error is encountered due to the audio format
@@ -1113,13 +1113,13 @@ Methods</h4>
 
 				2. Reject <var>promise</var> with <var>error</var>.
 
-				3. If <dfn>errorCallback</dfn> is not missing, invoke <a> errorCallback</a> with <var>error</var>.
+				3. If {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} is not missing, invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument} with <var>error</var>.
 
 			3. Otherwise:
 				1. Take the result, representing the decoded linear PCM
 					audio data, and resample it to the sample-rate of the
 					{{AudioContext}} if it is different from
-					the sample-rate of <a>audioData</a>.
+					the sample-rate of {{BaseAudioContext/decodeAudioData()/audioData!!argument}}.
 
 				2. Queue a task on the <a>control thread</a>'s event loop
 					to execute the following steps:


### PR DESCRIPTION
Fix up links to audioData, errorCallback, and successCallback in the decodeAudioData method.