### PR TITLE
Fix link to Biquad computedFrequency

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5437,7 +5437,7 @@ filter type is <code>"lowpass"</code>.
 Both {{BiquadFilterNode/frequency}}
 and {{BiquadFilterNode/detune}} form
 a <a>compound parameter</a> and are both <a>a-rate</a>. They are used
-together to determine a <dfn id="computedFreq-biquad">computedFrequency</dfn> value:
+together to determine a <dfn>computedFrequency</dfn> value:
 
 <pre highlight>
 	computedFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
@@ -5816,7 +5816,7 @@ their computation, based on the <a>computedValue</a> of the
 
 * Let \(F_s\) be the value of the {{BaseAudioContext/sampleRate}} attribute for this {{AudioContext}}.
 
-* Let \(f_0\) be the value of the {{computedFrequency}}.
+* Let \(f_0\) be the value of the <a>computedFrequency</a>.
 
 * Let \(G\) be the value of the {{BiquadFilterNode/gain}} {{AudioParam}}.
 


### PR DESCRIPTION
No need for an id, and just use `<a>` for the link.