### PR TITLE
Fix links to atomically.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -34,7 +34,7 @@ Abstract: This specification describes a high-level Web <abbr title="Application
 	For games and interactive applications,
 	it is anticipated to be used with the <code>canvas</code> 2D [[2dcontext]]
 	and WebGL [[WEBGL]] 3D graphics APIs.
-Markup Shorthands: markdown on, css off
+Markup Shorthands: markdown on, dfn on, css off
 </pre>
 
 <pre class=anchors>
@@ -743,7 +743,7 @@ Attributes</h4>
 		also the earliest possible time when any change scheduled in
 		the current state might take effect.
 
-		<code>currentTime</code> MUST be read <a lt="atomic">atomically</a> on the control thread before being
+		<code>currentTime</code> MUST be read <a>atomically</a> on the control thread before being
 		returned.
 
 	: <dfn>destination</dfn>
@@ -7038,7 +7038,7 @@ quantum of audio.
 8. Set <code>[[detector average]]</code> to <var>detector
 	average</var>.
 
-9. <a href="#atomic">Atomically</a> set the internal slot [[internal reduction]]
+9. <a>Atomically</a> set the internal slot [[internal reduction]]
 	to the value of <var>metering gain</var>.
 
 	Note: This step makes the metering gain update once per block, at the
@@ -10377,8 +10377,8 @@ Rendering an audio graph</h3>
 Rendering an audio graph is done in blocks of 128 samples-frames. A
 block of 128 samples-frames is called a <dfn>render quantum</dfn>.
 
-Operations that happen <dfn lt="atomic">atomically</dfn> on a
-given thread can only be executed when no other <a>atomic</a>
+Operations that happen <dfn>atomically</dfn> on a
+given thread can only be executed when no other [=Atomically|atomic=]
 operation is running on another thread.
 
 The algorithm for rendering a block of audio from an


### PR DESCRIPTION
* Enable 'dfn on' for Markup Shorthands
* Use simple dfn for Atomically
* Simplify links to Atmoically to use plain `<a>`.
* Make "atomic" link to Atomically in the one existing place.