### PR TITLE
Fix up algorithm vars

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1944,8 +1944,8 @@ Methods</h4>
 				<code>numberOfChannels</code>, <code>length</code> and
 				<code>sampleRate</code> values passed to this instance's
 				constructor in the <code>contextOptions</code> parameter.
-				Assign this buffer to an internal slot <a><var>[[rendered
-				buffer]]</var></a> in the {{OfflineAudioContext}}.
+				Assign this buffer to an internal slot
+				<dfn attribute for="OfflineAudioContext">[[rendered buffer]]</dfn> in the {{OfflineAudioContext}}.
 
 				<li>If an exception was thrown during the preceding
 				{{AudioBuffer}} constructor call, reject
@@ -1966,7 +1966,7 @@ Methods</h4>
 			<ol>
 				<li>Given the current connections and scheduled changes, start
 				rendering <code>length</code> sample-frames of audio into
-				<a><var>[[rendered buffer]]</var></a>.
+				{{[[rendered buffer]]}}
 
 				<li>For every <a>render quantum</a>, check and suspend the
 				rendering if necessary.
@@ -1978,14 +1978,13 @@ Methods</h4>
 				<a>control thread</a>'s event loop to perform the following
 				steps:
 					<ol>
-						<li>Resolve <var>promise</var> with <a><var>[[rendered
-						buffer]]</var></a>.
+						<li>Resolve <var>promise</var> with {{[[rendered buffer]]}}.
 
 						<li>Queue a task to fire an event named
 						<code>complete</code> at this instance, using an instance
 						of {{OfflineAudioCompletionEvent}} whose
 						<code>renderedBuffer</code> property is set to
-						<a><var>[[rendered buffer]]</var></a>.
+						{{[[rendered buffer]]}}.
 
 					</ol>
 

--- a/index.bs
+++ b/index.bs
@@ -2172,7 +2172,7 @@ Constructors</h4>
 
 		Set the internal slot {{[[internal data]]}} of this
 		{{AudioBuffer}} to the result of calling <a href="https://tc39.github.io/ecma262/#sec-createbytedatablock"><code>
-		CreateByteDataBlock([[\length]] * [[number of
+		CreateByteDataBlock([[length]] * [[number of
 		channels]])</code></a>.
 
 		Note: This initializes the underlying storage to zero.
@@ -2191,7 +2191,7 @@ Attributes</h4>
 		Duration of the PCM audio data in seconds.
 
 		This is computed from the {{[[sample rate]]}} and the
-		{{[[\length]]}} of the {{AudioBuffer}} by performing
+		{{[[length]]}} of the {{AudioBuffer}} by performing
 		a division between the {{AudioBuffer/[[length]]}} and the
 		{{[[sample rate]]}}.
 

--- a/index.bs
+++ b/index.bs
@@ -2128,19 +2128,19 @@ An {{AudioBuffer}} may be used by one or more
 {{AudioBuffer}} has four internal slots:
 
 <dl dfn-type=attribute dfn-for="AudioBuffer">
-	: <dfn>\[[number of channels]]</dfn>
+	: <dfn attribute for="AudioBuffer">[[number of channels]]</dfn>
 	::
 		The number of audio channels for this {{AudioBuffer}}, which is an unsigned long.
 
-	: <dfn>\[[length]]</dfn>
+	: <dfn attribute for="AudioBuffer">\[[length]]</dfn>
 	::
 		The length of each channel of this {{AudioBuffer}}, which is an unsigned long.
 
-	: <dfn>\[[sample rate]]</dfn>
+	: <dfn attribute for="AudioBuffer">[[sample rate]]</dfn>
 	::
 		The sample-rate, in Hz, of this {{AudioBuffer}}, a float
 
-	: <dfn>\[[internal data]]</dfn>
+	: <dfn attribute for="AudioBuffer">[[internal data]]</dfn>
 	::
 		A [=data block=] holding the audio sample data.
 </dl>
@@ -2169,9 +2169,7 @@ Constructors</h4>
 		Respectively assign the values of the attributes
 		<var>numberOfChannels</var>, <var>length</var>,
 		<var>sampleRate</var> of the {{AudioBufferOptions}} passed
-		in the constructor to the internal slots <var>[[number of
-		channels]]</var>, {{[[length]]}}, <var>[[sample
-		rate]]</var>.
+		in the constructor to the internal slots {{[[number of channels]]}}, {{[[length]]}}, {{[[sample rate]]}}.
 
 		Set the internal slot {{[[internal data]]}} of this
 		{{AudioBuffer}} to the result of calling <a href="https://tc39.github.io/ecma262/#sec-createbytedatablock"><code>
@@ -2195,13 +2193,13 @@ Attributes</h4>
 
 		This is computed from the {{[[sample rate]]}} and the
 		{{[[\length]]}} of the {{AudioBuffer}} by performing
-		a division between the {{[[length]]}} and the
+		a division between the {{AudioBuffer/[[length]]}} and the
 		{{[[sample rate]]}}.
 
 	: <dfn>length</dfn>
 	::
 		Length of the PCM audio data in sample-frames. This MUST return
-		the value of {{[[length]]}}.
+		the value of {{AudioBuffer/[[length]]}}.
 
 	: <dfn>numberOfChannels</dfn>
 	::

--- a/index.bs
+++ b/index.bs
@@ -2127,19 +2127,19 @@ An {{AudioBuffer}} may be used by one or more
 {{AudioBuffer}} has four internal slots:
 
 <dl dfn-type=attribute dfn-for="AudioBuffer">
-	: <dfn attribute for="AudioBuffer">[[number of channels]]</dfn>
+	: <dfn>[[number of channels]]</dfn>
 	::
 		The number of audio channels for this {{AudioBuffer}}, which is an unsigned long.
 
-	: <dfn attribute for="AudioBuffer">\[[length]]</dfn>
+	: <dfn>\[[length]]</dfn>
 	::
 		The length of each channel of this {{AudioBuffer}}, which is an unsigned long.
 
-	: <dfn attribute for="AudioBuffer">[[sample rate]]</dfn>
+	: <dfn>[[sample rate]]</dfn>
 	::
 		The sample-rate, in Hz, of this {{AudioBuffer}}, a float
 
-	: <dfn attribute for="AudioBuffer">[[internal data]]</dfn>
+	: <dfn>[[internal data]]</dfn>
 	::
 		A [=data block=] holding the audio sample data.
 </dl>


### PR DESCRIPTION
Make the internal slots/vars display and link correctly.

This currently only covers the `AudioBuffer` slots and `[[rendered buffer]]`.

There are many more to go, which will be handled in followups.