### PR TITLE
Add attributes to algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4541,8 +4541,8 @@ Methods</h4>
 				in the messsage.
 		</div>
 
-		<div algorithm="run a control message to start the AudioBufferSourceNode">
-			Running a <a>control message</a> to start the
+		<div algorithm="run a control message to stop the AudioBufferSourceNode">
+			Running a <a>control message</a> to stop the
 			{{AudioBufferSourceNode}} means invoking the
 			<code>handleStop()</code> function in the <a href="#playback-AudioBufferSourceNode">playback algorithm</a> which
 			follows.

--- a/index.bs
+++ b/index.bs
@@ -3326,7 +3326,7 @@ Methods</h4>
 		behavior of {{AudioParam/cancelAndHoldAtTime()}} is therefore
 		specified in the following algorithm.
 
-		<div algorithm>
+		<div algorithm="cancel and hold">
 			Let \(t_c\) be the value of <code>cancelTime</code>. Then
 
 			1. Let \(E_1\) be the event (if any) at time \(t_1\) where
@@ -4194,7 +4194,7 @@ performed:
 In the following, let \(N\) be the value of the
 {{AnalyserNode/fftSize}} attribute of this {{AnalyserNode}}.
 
-<div algorithm>
+<div algorithm="apply blackman window">
 	<dfn id="blackman-window">Applying a Blackman window</dfn> consists
 	in the following operation on the input time domain data. Let
 	\(x[n]\) for \(n = 0, \ldots, N - 1\) be the time domain data. The
@@ -4220,7 +4220,7 @@ In the following, let \(N\) be the value of the
 	</pre>
 </div>
 
-<div algorithm>
+<div algorithm="apply fourier transform">
 	<dfn id="fourier-transform">Applying a Fourier transform</dfn>
 	consists of computing the Fourier transform in the following way.
 	Let \(X[k]\) be the complex frequency domain data and
@@ -4236,7 +4236,7 @@ In the following, let \(N\) be the value of the
 	for \(k = 0, \dots, N/2-1\).
 </div>
 
-<div algorithm>
+<div algorithm="smoothing over time">
 	<dfn id="smoothing-over-time">Smoothing over time</dfn> frequency
 	data consists in the following operation:
 
@@ -4261,7 +4261,7 @@ In the following, let \(N\) be the value of the
 	for \(k = 0, \ldots, N - 1\).
 </div>
 
-<div algorithm>
+<div algorithm="conversion to db">
 	<dfn id="conversion-to-db">Conversion to dB</dfn> consists of the
 	following operation, where \(\hat{X}[k]\) is computed in <a>smoothing over time</a>:
 
@@ -7049,7 +7049,7 @@ knee and threshold parameter of the compressor, and not on the
 input signal. The intent here is to increase the output level of
 the compressor so it is comparable to the input level.
 
-<div algorithm>
+<div algorithm="computing makeup gain">
 	<dfn>Computing the makeup gain</dfn> means executing the following steps:
 
 	1. Let <var>full range gain</var> be the value returned by
@@ -7062,7 +7062,7 @@ the compressor so it is comparable to the input level.
 		gain</var>.
 </div>
 
-<div algorithm>
+<div algorithm="computing envelope rate">
 	<dfn>Computing the envelope rate</dfn> is done
 	by applying a function to the ratio of the <var>compressor
 	gain</var> and the <var>detector average</var>. User-agents are
@@ -7100,7 +7100,7 @@ Note: It is allowed, for example, to have a compressor that performs an
 compression, or to have curves for attack and release that are not
 of the same shape.
 
-<div algorithm>
+<div algorithm="apply decompression">
 	Applying a <dfn>compression curve</dfn> to a value means computing
 	the value of this sample when passed to a function, and returning
 	the computed value. This function MUST respect the following
@@ -7121,7 +7121,7 @@ of the same shape.
 		\frac{1}{ratio} \cdot x \)).
 </div>
 
-<div algorithm>
+<div algorithm="convert linear to db">
 	Converting a value \(v\) in <dfn id="linear-to-decibel">linear gain
 	unit to decibel means</dfn> executing the following steps:
 
@@ -7130,7 +7130,7 @@ of the same shape.
 	2. Else, return \( 20 \, \log_{10}{v} \)
 </div>
 
-<div algorithm>
+<div algorithm="convert db to linear">
 	Converting a value \(v\) in <dfn id="db-to-linear">decibels to
 	linear gain unit</dfn> means returning \(10^\frac{v}{20}\)
 </div>
@@ -8566,7 +8566,7 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="PeriodicWave">
 	: <dfn>PeriodicWave(context, options)</dfn>
 	::
-		<div algorithm>
+		<div algorithm="construct periodic wave">
 			1. Let <var>p</var> be a new {{PeriodicWave}} object. Let
 				<var>[[associated context]]</var> be a reference to the
 				{{BaseAudioContext}} passed as first argument of this
@@ -10315,7 +10315,7 @@ message to the end of the <a>control message queue</a> of an
 by time of insertion. The <dfn>oldest message</dfn> is therefore the
 one at the front of the <a>control message queue</a>.
 
-<div algorithm>
+<div algorithm="swapping control message queue">
 	<dfn lt="swap">Swapping</dfn> a <a>control message queue</a>
 	<var>Q<sub>A</sub></var> with another <a>control message queue</a>
 	<var>Q<sub>B</sub></var> means executing the following steps:
@@ -10455,7 +10455,7 @@ can restart executing this algoritm if needed.
 
 		2. <a>Visit</a> <em>node</em>.
 
-		<div algorithm>
+		<div algorithm="visiting a node">
 			<dfn lt="Visit">Visiting a node</dfn> <em>node</em>
 			means performing the following steps:
 


### PR DESCRIPTION
Some algorithms didn't have an attribute.  Add one to all such markup
that had an empty attribute.

Get's rid of the bikeshed fatal error about algorithm ''.  Don't know
which one was causing this, so fixed them all.