### PR TITLE
Fix fatal error about incorrect indentation.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1677,9 +1677,9 @@ Methods</h4>
 			1. Let <em>promise</em> be a new Promise.
 
 			2. If the <em>control thread state</em> flag on the
-			{{AudioContext}} is <code>closed</code> reject the promise
-			with {{InvalidStateError}}, abort these steps,
-			returning <em>promise</em>.
+				{{AudioContext}} is <code>closed</code> reject the promise
+				with {{InvalidStateError}}, abort these steps,
+				returning <em>promise</em>.
 
 			3. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is already <code>suspended</code>,
 				resolve <em>promise</em>, return it, and abort these steps.


### PR DESCRIPTION
The error message said:

FATAL ERROR: Line 21 isn't indented enough (needs 2 indents) to be valid Markdown:
"       {{AudioContext}} is <code>closed</code> reject the promise"
FATAL ERROR: Line 22 isn't indented enough (needs 2 indents) to be valid Markdown:
"       with {{InvalidStateError}}, abort these steps,"
FATAL ERROR: Line 23 isn't indented enough (needs 2 indents) to be valid Markdown:
"       returning <em>promise</em>."

@tabatkins FYI so you know what the fix is and maybe fix the issue
with the wrong line numbers.