### PR TITLE
Fix up links to channel mode and interpretation

### DIFF
--- a/audionode.include
+++ b/audionode.include
@@ -19,11 +19,11 @@
 			<td>[CC-NOTES?]
 		<tr>
 			<td>{{AudioNode/channelCountMode}}
-			<td>{{ChannelCountMode/"[CC-MODE]"}}
+			<td>"{{ChannelCountMode/[CC-MODE]}}"
 			<td>[CC-MODE-NOTES?]
 		<tr>
 			<td>{{AudioNode/channelInterpretation}}
-			<td>{{ChannelInterpretation/"[CC-INTERP]"}}
+			<td>"{{ChannelInterpretation/[CC-INTERP]}}"
 			<td>[CC-INTERP-NOTES?]
 		<tr>
 			<td><a>tail-time</a> reference


### PR DESCRIPTION
Bikeshed generates errors about things like
`{{ChannelCountMode/"max"}}`.  Replace the template to generate
`"{{ChannelCountMode/max}}"` which doesn't generate an error and also
correctly generates the desired link to the property definition.