### PR TITLE
Add node info and audioparam table styling

### DIFF
--- a/audionode-noinput.include
+++ b/audionode-noinput.include
@@ -1,4 +1,5 @@
-<table class="node-info">
+<div class="node-info">
+<table>
 	<thead>
 		<tr>
 			<th>Property
@@ -17,3 +18,4 @@
 			<td>[TAIL-TIME]
 			<td>[TIME-TIME-NOTES?]
 </table>
+</div>

--- a/audionode.include
+++ b/audionode.include
@@ -1,4 +1,5 @@
-<table class="node-info">
+<div class="node-info">
+<table>
 	<thead>
 		<tr>
 			<th>Property
@@ -30,3 +31,4 @@
 			<td>[TAIL-TIME]
 			<td>[TAIL-TIME-NOTES?]
 </table>
+</div>

--- a/audioparam.include
+++ b/audioparam.include
@@ -1,4 +1,5 @@
-<table class="audioparam-info">
+<div class="audioparam-info">
+<table>
 	<thead>
 		<tr>
 			<th>Parameter
@@ -22,3 +23,4 @@
 			<td>[RATE]
 			<td>[RATE-NOTES?]
 </table>
+</div>

--- a/index.bs
+++ b/index.bs
@@ -127,43 +127,47 @@ table.channels tr:nth-child(even) {
 table.channels tr:nth-child(odd) {
 	background: #FFF;
 }
-table.node-info {
+div.node-info {
 	padding-left: 4em;
 	padding-right: 4em;
+}
+div.node-info > table {
 	border-collapse: collapse;
 	border-top: 2px solid #707070;
 	border-bottom: 2px solid #707070;
 	width: 100%;
 	margin: 2em 0;
 }
-table.node-info > tbody > tr > th,
-table.node-info > tbody > tr > td {
+div.node-info > table > tbody > tr > th,
+div.node-info > table > tbody > tr > td {
 	padding: 0.2em 0.6em;
 	min-width: 150px;
 	border-top: 1px solid #ddd
 }
-table.node-info > tbody > tr > th {
+div.node-info > table > thead > tr > th {
 	line-height: 2em;
 	font-weight: 600;
 	color: #178217;
 	border-bottom: 1px solid #707070;
 }
-table.audioparam-info {
-	padding-left: 2em;
+div.audioparam-info {
+	padding-left: 4em;
 	padding-right: 4em;
+}    
+div.audioparam-info > table {
 	border-collapse: collapse;
 	border-top: 2px solid #707070;
 	border-bottom: 2px solid #707070;
 	width: 100%;
 	margin: 2em 0;
 }
-table.audioparam-info > tbody > tr > th,
-table.audioparam-info > tbody > tr > td {
+div.audioparam-info > table > tbody > tr > th,
+div.audioparam-info > table > tbody > tr > td {
 	padding: 0.2em 0.6em;
 	min-width: 150px;
 	border-top: 1px solid #ddd
 }
-table.audioparam-info > tbody > tr > th {
+div.audioparam-info > table > thead > tr > th {
 	line-height: 2em;
 	font-weight: 600;
 	color: #178217;


### PR DESCRIPTION
Puts back the original styling (more or less) fo the node properties
table and the audioparam properties table.