### PR TITLE
Clean display of examples for AudioNode.connect

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3701,7 +3701,7 @@ the clamping done as specified above.
 	For example, consider a node \(N\) has an AudioParam \(p\) with a
 	nominal range of \([0, 1]\), and following automation sequence
 
-	<pre>
+	<pre highlight="js">
 		N.p.setValueAtTime(0, 0);
 		N.p.linearRampToValueAtTime(4, 1);
 		N.p.linearRampToValueAtTime(0, 2);

--- a/index.bs
+++ b/index.bs
@@ -2847,14 +2847,14 @@ Methods</h4>
 		<div class=example>
 			For example:
 
-			<pre class="example" highlight="js">
+			<pre highlight="js">
 				nodeA.connect(nodeB);
 				nodeA.connect(nodeB);
 			</pre>
 
 			will have the same effect as
 
-			<pre class="example" highlight="js">
+			<pre highlight="js">
 				nodeA.connect(nodeB);
 			</pre>
 		</div>
@@ -2909,14 +2909,14 @@ Methods</h4>
 		<div class=example>
 			For example:
 
-			<pre>
+			<pre highlight="js">
 				nodeA.connect(param);
 				nodeA.connect(param);
 			</pre>
 
 			will have the same effect as
 
-			<pre>
+			<pre highlight="js">
 				nodeA.connect(param);
 			</pre>
 		</div>


### PR DESCRIPTION
* The example for connect(destinationNode) incorrectly nested examples
  inside an example.  Fix that, basically making it look like the
  example in connect(destinationParam).

* Add syntax highlighting for the code snippets in the examples.