### PR TITLE
Fix more fatal errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -914,7 +914,7 @@ Methods</h4>
 		<a>Factory method</a> for a {{DelayNode}}. The initial default
 		delay time will be 0 seconds.
 
-		<pre class=argumentdef for="BaseAudioContext/createDelay()">
+		<pre class=argumentdef for="BaseAudioContext/createDelay(maxDelayTime)">
 		maxDelayTime: Specifies the maximum delay time in seconds allowed for the delay line. <span class="synchronous">If specified, this value MUST be greater than zero and less than three minutes or a {{NotSupportedError}} exception MUST be thrown.</span> If not specified, then `1` will be used.
 		</pre>
 
@@ -1021,7 +1021,7 @@ Methods</h4>
 		This method is DEPRECATED, as it is intended to be replaced by {{AudioWorkletNode}}.
 		Creates a {{ScriptProcessorNode}} for direct audio processing using scripts.
 		<span class="synchronous">An {{IndexSizeError}} exception MUST be thrown if
-		{{bufferSize!!argument}} or {{numberOfInputChannels}} or {{numberOfOutputChannels}}
+		{{createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels)/bufferSize}} or {{createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels)/numberOfInputChannels}} or {{createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels)/numberOfOutputChannels}}
 		are outside the valid range.</span>
 
 		It is invalid for both {{numberOfInputChannels}} and {{numberOfOutputChannels}} to be zero.
@@ -1389,9 +1389,9 @@ Constructors</h4>
 
 			1. Set a <code>control thread state</code> to <code>suspended</code> on the {{AudioContext}}.
 
-			2. Set a <dfn>rendering thread state</dfn> to <code>suspended</code> on the {{AudioContext}}.
+			2. Set a <dfn dfn for>rendering thread state</dfn> to <code>suspended</code> on the {{AudioContext}}.
 
-			3. Let <dfn>pendingResumePromises</dfn> be an empty ordered list of promises.
+			3. Let <dfn dfn for>pendingResumePromises</dfn> be an empty ordered list of promises.
 
 			4. If <code>contextOptions</code> is given, apply the options:
 
@@ -1972,7 +1972,7 @@ Methods</h4>
 		</div>
 
 		<div algorithm="begin offline rendering">
-			To <dfn>begin offline rendering</dfn>, the following steps MUST
+			To <dfn dfn for>begin offline rendering</dfn>, the following steps MUST
 			happen on a <a>rendering thread</a> that is created for the
 			occasion.
 

--- a/index.bs
+++ b/index.bs
@@ -1021,7 +1021,7 @@ Methods</h4>
 		This method is DEPRECATED, as it is intended to be replaced by {{AudioWorkletNode}}.
 		Creates a {{ScriptProcessorNode}} for direct audio processing using scripts.
 		<span class="synchronous">An {{IndexSizeError}} exception MUST be thrown if
-		{{createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels)/bufferSize}} or {{createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels)/numberOfInputChannels}} or {{createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels)/numberOfOutputChannels}}
+		{{bufferSize}} or {{numberOfInputChannels}} or {{numberOfOutputChannels}}
 		are outside the valid range.</span>
 
 		It is invalid for both {{numberOfInputChannels}} and {{numberOfOutputChannels}} to be zero.
@@ -2869,7 +2869,7 @@ Methods</h4>
 		<pre class=argumentdef for="AudioNode/connect(destinationNode, output, input)">
 			destinationNode: The <code>destination</code> parameter is the {{AudioNode}} to connect to. If the <code>destination</code> parameter is an {{AudioNode}} that has been created using another {{AudioContext}}, an {{InvalidAccessError}} MUST be thrown. That is, {{AudioNode}}s cannot be shared between {{AudioContext}}s.
 			output: The <code>output</code> parameter is an index describing which output of the {{AudioNode}} from which to connect. <span class="synchronous">If this parameter is out-of-bound, an {{IndexSizeError}} exception MUST be thrown.</span> It is possible to connect an {{AudioNode}} output to more than one input with multiple calls to connect(). Thus, "fan-out" is supported.
-			input:  The <code>input</code> parameter is an index describing which input of the destination {{AudioNode}} to connect to. <span class="synchronous">If this parameter is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span> It is possible to connect an {{AudioNode}} to another {{AudioNode}} which creates a <dfn>cycle</dfn>: an {{AudioNode}} may connect to another {{AudioNode}}, which in turn connects back to the input or {{AudioParam}} of the first {{AudioNode}}. This is allowed only if there is at least one {{DelayNode}} in the <em>cycle</em> <span class="synchronous">or a {{NotSupportedError}} exception MUST be thrown.</span>
+			input:  The <code>input</code> parameter is an index describing which input of the destination {{AudioNode}} to connect to. <span class="synchronous">If this parameter is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span> It is possible to connect an {{AudioNode}} to another {{AudioNode}} which creates a <dfn dfn for>cycle</dfn>: an {{AudioNode}} may connect to another {{AudioNode}}, which in turn connects back to the input or {{AudioParam}} of the first {{AudioNode}}. This is allowed only if there is at least one {{DelayNode}} in the <em>cycle</em> <span class="synchronous">or a {{NotSupportedError}} exception MUST be thrown.</span>
 		</pre>
 
 		<div>

--- a/index.bs
+++ b/index.bs
@@ -1490,8 +1490,8 @@ Methods</h4>
 <dl dfn-type=method dfn-for="AudioContext">
 	: <dfn>close()</dfn>
 	::
-		Closes the {{AudioContext}}, <a>releasing the system
-		resources</a> it's using. This will not automatically release
+		Closes the {{AudioContext}}, [=release system resources|releasing the system
+		resources=] it's using. This will not automatically release
 		all {{AudioContext}}-created objects, but will suspend the
 		progression of the {{AudioContext}}'s
 		{{BaseAudioContext/currentTime}}, and stop


### PR DESCRIPTION
Fix these errors:

>FATAL ERROR: Functions/methods must end with () in their linking text, got 'rendering thread state'.
FATAL ERROR: Functions/methods must end with () in their linking text, got 'pendingResumePromises'.
FATAL ERROR: Functions/methods must end with () in their linking text, got 'begin offline rendering'.
FATAL ERROR: Functions/methods must end with () in their linking text, got 'cycle'.
LINK ERROR: No 'argument' refs found for 'maxDelayTime'.
<a data-lt="maxDelayTime" class="nv" data-link-type="argument" data-link-for="BaseAudioContext/createDelay(maxDelayTime), BaseAudioContext/createDelay()">maxDelayTime</a>
LINK ERROR: No 'dfn' refs found for 'pendingresumepromises'.
<a data-link-type="dfn" data-lt="pendingResumePromises">pendingResumePromises</a>
LINK ERROR: No 'dfn' refs found for 'rendering thread state'.
<a data-link-type="dfn" data-lt="rendering thread state">rendering thread state</a>
LINK ERROR: No 'dfn' refs found for 'releasing the system resources'.
<a data-link-type="dfn" data-lt="releasing the system resources">releasing the system
resources</a>
LINK ERROR: No 'dfn' refs found for 'begin offline rendering'.
<a data-link-type="dfn" data-lt="begin offline rendering">begin offline rendering</a>
LINK ERROR: No 'dfn' refs found for 'cycle'.
<a data-link-type="dfn" data-lt="cycle">cycle</a>
