### PR TITLE
Fix illegal nesting of AudioBuffer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2305,7 +2305,7 @@ accessing the resulting array, because it may avoid unnecessary
 memory allocation and copying.
 
 An internal operation <a href="#acquire-the-content">acquire the
-contents of an {{AudioBuffer}}</a> is invoked when the
+contents of an AudioBuffer</a> is invoked when the
 contents of an {{AudioBuffer}} are needed by some API
 implementation. This operation returns immutable channel data to the
 invoker.


### PR DESCRIPTION
We had `{{AudioBuffer}}` nested inside an `<a>` tag.  Bikeshed warns
about that, so don't linkify `AudioBuffer`.  It's not really needed
anyway.